### PR TITLE
53 - Support Frame Locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to use testla you need to [install](https://playwright.dev/docs/intro) 
 Get started by installing Testla Screenplay for Playwright using npm. 
 
 ```bash
-npm install --save-dev testa-screenplay-playwright
+npm install --save-dev testla-screenplay-playwright
 ```
 
 ## 👨‍🏫 Learn Testla

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -2,6 +2,8 @@ import { Locator } from '@playwright/test';
 
 export type Selector = string | Locator;
 
+export type FrameSelector = string;
+
 export type SelectorOptionsState = 'visible' | 'hidden' | 'attached' | 'detached';
 
 export type SubSelector = [
@@ -13,4 +15,5 @@ export type SelectorOptions = {
     subSelector?: SubSelector;
     timeout?: number;
     state?: SelectorOptionsState;
+    frameSelector?: FrameSelector;
 };

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -42,3 +42,4 @@ export const recursiveLocatorLookup = async ({ page, selector, options }: { page
         page, locator, timeout: options?.timeout, subSelector: options?.subSelector, state: options?.state, evaluateVisible: options?.evaluateVisible,
     });
 };
+// ?


### PR DESCRIPTION
Issue number: resolves #53 

## Proposed changes

A page can have one or more frame objects attached to it. Each page has a main frame and page-level interactions (like click) are assumed to operate in the main frame.

A page can have additional frames attached with the iframe HTML tag. These frames can be accessed for interactions inside the frame. 

FrameLocator represents a view to the iframe on the page. It captures the logic sufficient to retrieve the iframe and locate elements in that iframe. 

## Types of changes

What types of changes does your code introduce to Testla?
_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Regression
- [x] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and (unit) tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated necessary documentation
