### PR TITLE
53 2 support frame locators as playwright

### DIFF
--- a/__tests__/web.spec.ts
+++ b/__tests__/web.spec.ts
@@ -176,6 +176,28 @@ test.describe('Testing screenplay-playwright-js web module', () => {
         await expect(BrowseTheWeb.as(actor).getPage().locator('[id="result"]')).toHaveText('You entered: C');
     });
 
+    test('Handle iFrames', async ({ actor }) => {
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/iframe'),
+            Wait.forLoadState('networkidle'),
+        );
+
+        expect(await actor.asks(
+            Element.toBe.visible('#tinymce', { hasText: 'Your content goes here.' }).inFrame('#mce_0_ifr'),
+        )).toBe(true);
+    });
+
+    test('Handle nested Frames', async ({ actor }) => {
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/nested_frames'),
+            Wait.forLoadState('networkidle'),
+        );
+
+        expect(await actor.asks(
+            Element.toBe.visible('#content', { hasText: 'MIDDLE' }).inFrame('[name="frame-top"]').inFrame('[name="frame-middle"]'),
+        )).toBe(true);
+    });
+
     test('Wait + Recursive Locators', async ({ actor }) => {
         await actor.attemptsTo(
             Navigate.to('https://the-internet.herokuapp.com/tables'),

--- a/__tests__/web_playwright_locators.spec.ts
+++ b/__tests__/web_playwright_locators.spec.ts
@@ -160,6 +160,30 @@ test.describe('Testing screenplay-playwright-js web module', () => {
         await expect(page.locator('[id="result"]')).toHaveText('You entered: C');
     });
 
+    test('Handle iFrames', async ({ actor }) => {
+        const page: Page = BrowseTheWeb.as(actor).getPage();
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/iframe'),
+            Wait.forLoadState('networkidle'),
+        );
+
+        expect(await actor.asks(
+            Element.toBe.visible(page.frameLocator('#mce_0_ifr').locator('#tinymce', { hasText: 'Your content goes here.' })),
+        )).toBe(true);
+    });
+
+    test('Handle nested Frames', async ({ actor }) => {
+        const page: Page = BrowseTheWeb.as(actor).getPage();
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/nested_frames'),
+            Wait.forLoadState('networkidle'),
+        );
+
+        expect(await actor.asks(
+            Element.toBe.visible(page.frameLocator('[name="frame-top"]').frameLocator('[name="frame-middle"]').locator('#content', { hasText: 'MIDDLE' })),
+        )).toBe(true);
+    });
+
     test('Wait + Recursive Locators', async ({ actor }) => {
         const page: Page = BrowseTheWeb.as(actor).getPage();
 

--- a/docs/guides/frame_handling/frame_handling.md
+++ b/docs/guides/frame_handling/frame_handling.md
@@ -1,0 +1,47 @@
+[Back to overview](../guides.md)
+
+# Handling Frame(s)
+
+A webpage may be associated with multiple Frame objects. Each webpage possesses a primary frame, and interactions at the page level, 
+such as clicking, are typically performed within this main frame. In addition to the main frame, a webpage can incorporate extra 
+frames using the HTML 'iframe' tag. These supplementary frames can be targeted for interactions occurring within the specific frame.
+
+## How to handling Frames
+
+### Handling single Frames
+
+You can access frame objects using the `inFrame()` API:
+
+```typescript
+    test('Handle iFrames', async ({ actor }) => {
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/iframe'),
+            Wait.forLoadState('networkidle'),
+        );
+
+        expect(await actor.asks(
+            Element.toBe.visible('#tinymce', { hasText: 'Your content goes here.' }).inFrame('#mce_0_ifr'),
+        )).toBe(true);
+    });
+```
+
+### Handling nested Frames
+
+You can also chain frame objects using the `inFrame()` API.
+> [!IMPORTANT]
+> Be aware the sequence starts at the top iframe and goes down to the lowest iframe
+
+```typescript
+    test('Handle nested Frames', async ({ actor }) => {
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/nested_frames'),
+            Wait.forLoadState('networkidle'),
+        );
+
+        expect(await actor.asks(
+            Element.toBe.visible('#content', { hasText: 'MIDDLE' }).inFrame('[name="frame-top"]').inFrame('[name="frame-middle"]'),
+        )).toBe(true);
+    });
+```
+
+[Back to overview](../guides.md)

--- a/docs/guides/frame_handling/frame_handling.md
+++ b/docs/guides/frame_handling/frame_handling.md
@@ -13,35 +13,17 @@ frames using the HTML 'iframe' tag. These supplementary frames can be targeted f
 You can access frame objects using the `inFrame()` API:
 
 ```typescript
-    test('Handle iFrames', async ({ actor }) => {
-        await actor.attemptsTo(
-            Navigate.to('https://the-internet.herokuapp.com/iframe'),
-            Wait.forLoadState('networkidle'),
-        );
-
-        expect(await actor.asks(
-            Element.toBe.visible('#tinymce', { hasText: 'Your content goes here.' }).inFrame('#mce_0_ifr'),
-        )).toBe(true);
-    });
+Element.toBe.visible('#tinymce', { hasText: 'Your content goes here.' }).inFrame('#mce_0_ifr');
 ```
 
 ### Handling nested Frames
 
 You can also chain frame objects using the `inFrame()` API.
 > [!IMPORTANT]
-> Be aware the sequence starts at the top iframe and goes down to the lowest iframe
+> Be aware the sequence starts with outer most iframe and goes down to inner most iframe
 
 ```typescript
-    test('Handle nested Frames', async ({ actor }) => {
-        await actor.attemptsTo(
-            Navigate.to('https://the-internet.herokuapp.com/nested_frames'),
-            Wait.forLoadState('networkidle'),
-        );
-
-        expect(await actor.asks(
-            Element.toBe.visible('#content', { hasText: 'MIDDLE' }).inFrame('[name="frame-top"]').inFrame('[name="frame-middle"]'),
-        )).toBe(true);
-    });
+Element.toBe.visible('#content', { hasText: 'MIDDLE' }).inFrame('[name="frame-top"]').inFrame('[name="frame-middle"]');
 ```
 
 [Back to overview](../guides.md)

--- a/docs/guides/frame_handling/frame_handling.md
+++ b/docs/guides/frame_handling/frame_handling.md
@@ -2,23 +2,23 @@
 
 # Handling Frame(s)
 
-A webpage may be associated with multiple Frame objects. Each webpage possesses a primary frame, and interactions at the page level, 
+A webpage may be associated with multiple Frame objects. Each webpage possesses a primary frame and interactions at the page level 
 such as clicking, are typically performed within this main frame. In addition to the main frame, a webpage can incorporate extra 
 frames using the HTML 'iframe' tag. These supplementary frames can be targeted for interactions occurring within the specific frame.
 
-## How to handling Frames
+## How to handle Frames
 
 ### Handling single Frames
 
 You can access frame objects using the `inFrame()` API:
 
 ```typescript
-Element.toBe.visible('#tinymce', { hasText: 'Your content goes here.' }).inFrame('#mce_0_ifr');
+Element.toBe.visible('#myLocator', { hasText: 'Your content goes here.' }).inFrame('#myFrameLocator');
 ```
 
 ### Handling nested Frames
 
-You can also chain frame objects using the `inFrame()` API.
+You can also chain frame objects to go down to the inner most iframe using the `inFrame()` API.
 > [!IMPORTANT]
 > Be aware the sequence starts with outer most iframe and goes down to inner most iframe
 

--- a/docs/guides/guides.md
+++ b/docs/guides/guides.md
@@ -13,5 +13,7 @@
   - [Use it in your test](./advanced_test_setup/write_tests.md)
 - **Aliasing**
   - [Ability Aliasing](./ability_aliasing//ability_aliasing.md) - Using the same ability with different configurations
+- **Frame Handling**
+  - [Frame(s)](./frame_handling//frame_handling.md) - Handling frames
 
 [Back to overview](../../README.md)

--- a/docs/screenplay_elements/API/Actions/delete.md
+++ b/docs/screenplay_elements/API/Actions/delete.md
@@ -15,6 +15,7 @@ The `Delete` class provides a convenient way to perform HTTP DELETE requests. It
     - [from](#from)
     - [withHeaders](#withheaders)
     - [withResponseBodyFormat](#withresponsebodyformat)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -67,5 +68,16 @@ public withResponseBodyFormat(responseBodyFormat: ResponseBodyFormat): Delete;
 - **Parameters:**
   - `responseBodyFormat` - The desired format of the response body which can be one out of `json`, `text`, `buffer` or `none`. The default is `json`.
 - **Returns:** `Delete` - The updated instance of the `Delete` class.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Delete;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Delete` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/API/Actions/get.md
+++ b/docs/screenplay_elements/API/Actions/get.md
@@ -15,6 +15,7 @@ The `Get` class provides a convenient way to perform HTTP GET requests. It allow
     - [from](#from)
     - [withHeaders](#withheaders)
     - [withResponseBodyFormat](#withresponsebodyformat)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -67,5 +68,16 @@ public withResponseBodyFormat(responseBodyFormat: ResponseBodyFormat): Get;
 - **Parameters:**
   - `responseBodyFormat` - The desired format of the response body which can be one out of `json`, `text`, `buffer` or `none`. The default is `json`.
 - **Returns:** `Get` - The updated instance of the `Get` class.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Get;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Get` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/API/Actions/head.md
+++ b/docs/screenplay_elements/API/Actions/head.md
@@ -14,6 +14,7 @@ The `Head` class provides a convenient way to perform HTTP HEAD requests. It all
     - [performAs](#performas)
     - [from](#from)
     - [withHeaders](#withheaders)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -55,5 +56,16 @@ public withHeaders(headers: Headers): Head;
 - **Parameters:**
   - `headers` - The headers to be added.
 - **Returns:** `Head` - The updated instance of the `Head` class.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Head;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Head` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/API/Actions/patch.md
+++ b/docs/screenplay_elements/API/Actions/patch.md
@@ -16,6 +16,7 @@ The `Patch` class provides a convenient way to perform HTTP PATCH requests. It a
     - [withData](#withdata)
     - [withHeaders](#withheaders)
     - [withResponseBodyFormat](#withresponsebodyformat)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -79,5 +80,16 @@ public withResponseBodyFormat(responseBodyFormat: ResponseBodyFormat): Patch;
 - **Parameters:**
   - `responseBodyFormat` - The desired format of the response body which can be one out of `json`, `text`, `buffer` or `none`. The default is `json`.
 - **Returns:** `Patch` - The updated instance of the `Patch` class.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Patch;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Patch` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/API/Actions/post.md
+++ b/docs/screenplay_elements/API/Actions/post.md
@@ -16,6 +16,7 @@ The `Post` class provides a convenient way to perform HTTP POST requests. It all
     - [withData](#withdata)
     - [withHeaders](#withheaders)
     - [withResponseBodyFormat](#withresponsebodyformat)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -79,5 +80,16 @@ public withResponseBodyFormat(responseBodyFormat: ResponseBodyFormat): Post;
 - **Parameters:**
   - `responseBodyFormat` - The desired format of the response body which can be one out of `json`, `text`, `buffer` or `none`. The default is `json`.
 - **Returns:** `Post` - The updated instance of the `Post` class.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Post;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Post` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/API/Actions/put.md
+++ b/docs/screenplay_elements/API/Actions/put.md
@@ -16,6 +16,7 @@ The `Put` class provides a convenient way to perform HTTP PUT requests. It allow
     - [withData](#withdata)
     - [withHeaders](#withheaders)
     - [withResponseBodyFormat](#withresponsebodyformat)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -79,5 +80,16 @@ public withResponseBodyFormat(responseBodyFormat: ResponseBodyFormat): Put;
 - **Parameters:**
   - `responseBodyFormat` - The desired format of the response body which can be one out of `json`, `text`, `buffer` or `none`. The default is `json`.
 - **Returns:** `Put` - The updated instance of the `Put` class.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Put;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Put` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Ability/browse_the_web.md
+++ b/docs/screenplay_elements/Web/Ability/browse_the_web.md
@@ -115,19 +115,20 @@ public async waitForLoadState(status: 'load' | 'domcontentloaded' | 'networkidle
 #### hover
 
 ```typescript
-public async hover(selector: Selector, options?: SelectorOptions & { modifiers?: ('Alt' | 'Control' | 'Meta' | 'Shift')[] }): Promise<void>;
+public async hover(selector: Selector, options?: SelectorOptions & { modifiers?: ('Alt' | 'Control' | 'Meta' | 'Shift')[] }, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Uses the page mouse to hover over the specified element.
 - **Parameters:**
   - `selector` - The selector of the element to hover over.
   - `options` - (optional) Advanced selector lookup options + Modifier keys to press. Ensures that only these modifiers are pressed during the operation.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns when hovered over the element.
 
 #### press
 
 ```typescript
-public async pressSequentially(selector: Selector, input: string, options?: SelectorOptions): Promise<void>;
+public async pressSequentially(selector: Selector, input: string, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Types the given input into the element specified by the selector.
@@ -135,6 +136,7 @@ public async pressSequentially(selector: Selector, input: string, options?: Sele
   - `selector` - The selector of the source element.
   - `input` - The input to type into the element.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns when the key(s) have been pressed.
 
 ```typescript
@@ -149,31 +151,33 @@ public async press(input: string): Promise<void>;
 #### checkBox
 
 ```typescript
-public async checkBox(selector: Selector, options?: SelectorOptions): Promise<void>;
+public async checkBox(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Checks the specified checkbox.
 - **Parameters:**
   - `selector` - The selector of the checkbox.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns after checking the element.
 
 #### waitForSelector
 
 ```typescript
-public async waitForSelector(selector: Selector, options?: SelectorOptions): Promise<Locator>;
+public async waitForSelector(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<Locator>;
 ```
 
 - **Description:** Waits until the element of the specified selector exists.
 - **Parameters:**
   - `selector` - The selector of the element.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<Locator>` - Returns a `Locator` promise.
 
 #### dragAndDrop
 
 ```typescript
-public async dragAndDrop(sourceSelector: Selector, targetSelector: Selector, options?: { source?: SelectorOptions; target?: SelectorOptions; }): Promise<void>;
+public async dragAndDrop(sourceSelector: Selector, targetSelector: Selector, options?: { source?: SelectorOptions; target?: SelectorOptions; }, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Drags the specified source element to the specified target element and drops it.
@@ -181,12 +185,13 @@ public async dragAndDrop(sourceSelector: Selector, targetSelector: Selector, opt
   - `sourceSelector` - The selector of the source element.
   - `targetSelector` - The selector of the target element.
   - `options` - (optional) Advanced selector lookup options for source and target.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns after dragging the locator to another target locator or target position.
 
 #### fill
 
 ```typescript
-public async fill(selector: Selector, input: string, options?: SelectorOptions): Promise<void>;
+public async fill(selector: Selector, input: string, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Fills the element specified by the selector with the given input.
@@ -194,12 +199,13 @@ public async fill(selector: Selector, input: string, options?: SelectorOptions):
   - `selector` - The selector of the source element.
   - `input` - The input to fill the element with.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns after checks, focuses the element, fills it, and triggers an `input` event after filling.
 
 #### type
 
 ```typescript
-public async type(selector: Selector, input: string, options?: SelectorOptions): Promise<void>;
+public async type(selector: Selector, input: string, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Types the given input into the element specified by the selector.
@@ -207,36 +213,39 @@ public async type(selector: Selector, input: string, options?: SelectorOptions):
   - `selector` - The selector of the source element.
   - `input` - The input to type into the element.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Focuses the element and then sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
 
 #### click
 
 ```typescript
-public async click(selector: Selector, options?: SelectorOptions): Promise<void>;
+public async click(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Clicks the element specified by the selector.
 - **Parameters:**
   - `selector` - The selector of the element to click.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns after clicking the element.
 
 #### dblclick
 
 ```typescript
-public async dblclick(selector: Selector, options?: SelectorOptions): Promise<void>;
+public async dblclick(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void>;
 ```
 
 - **Description:** Double clicks the element specified by the selector.
 - **Parameters:**
   - `selector` - The selector of the element to double click.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<void>` - Returns after double clicking the element.
 
 #### checkVisibilityState
 
 ```typescript
-public async checkVisibilityState(selector: Selector, mode: 'visible' | 'hidden', options?: SelectorOptions): Promise<boolean>;
+public async checkVisibilityState(selector: Selector, mode: 'visible' | 'hidden', options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean>;
 ```
 
 - **Description:** Validates if a locator on the page is visible or hidden.
@@ -244,12 +253,13 @@ public async checkVisibilityState(selector: Selector, mode: 'visible' | 'hidden'
   - `selector` - The locator to search for.
   - `mode` - The expected property of the selector that needs to be checked, either visible (positive) or hidden (negative).
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<boolean>` - True if the element is visible/hidden as expected, false if the timeout was reached.
 
 #### checkEnabledState
 
 ```typescript
-public async checkEnabledState(selector: Selector, mode: 'enabled' | 'disabled', options?: SelectorOptions): Promise<boolean>;
+public async checkEnabledState(selector: Selector, mode: 'enabled' | 'disabled', options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean>;
 ```
 
 - **Description:** Validates if a locator on the page is enabled or disabled.
@@ -257,12 +267,13 @@ public async checkEnabledState(selector: Selector, mode: 'enabled' | 'disabled',
   - `selector` - The locator to search for.
   - `mode` - The expected property of the selector that needs to be checked, either 'enabled' or 'disabled'.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<boolean>` - True if the element is enabled/disabled as expected, false if the timeout was reached.
 
 #### checkSelectorText
 
 ```typescript
-public async checkSelectorText(selector: Selector, text: string | RegExp | (string | RegExp)[], mode: 'positive' | 'negative', options?: SelectorOptions): Promise<boolean>;
+public async checkSelectorText(selector: Selector, text: string | RegExp | (string | RegExp)[], mode: 'positive' | 'negative', options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean>;
 ```
 
 - **Description:** Validates if the given element has the given text or not.
@@ -271,20 +282,22 @@ public async checkSelectorText(selector: Selector, text: string | RegExp | (stri
   - `text` - The text to check.
   - `mode` - Whether to check if the element has (positive) or has not (negative) the specified text.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<boolean>` - True if the element has/doesn't have the specified text, false if the timeout was reached.
 
 #### checkSelectorValue
 
 ```typescript
-public async checkSelectorValue(selector: Selector, value: string | RegExp, mode: 'positive' | 'negative', options?: SelectorOptions): Promise<boolean>;
+public async checkSelectorValue(selector: Selector, value: string | RegExp, mode: 'positive' | 'negative', options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean>;
 ```
 
 - **Description:** Validates if the given element has the given input value or not.
 - **Parameters:**
-  - `selector` - The selector of the element to hover over.
+  - `selector` - The selector of the element to check.
   - `value` - The single value to check.
   - `mode` - Whether to check if the element has (positive) or has not (negative) the specified value.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<boolean>` - True if the element has/doesn't have the specified value, false if the timeout was reached.
 
 #### getCookies
@@ -389,7 +402,7 @@ public async removeSessionStorageItem(key: string): Promise<void>;
 #### selectOption
 
 ```typescript
-public async selectOption(selector: Selector, option: string | { value?: string, label?: string, index?: number }, selectorOptions?: SelectorOptions): Promise<any>;
+public async selectOption(selector: Selector, option: string | { value?: string, label?: string, index?: number }, selectorOptions?: SelectorOptions, frameTree?: FrameSelector[]): Promise<any>;
 ```
 
 - **Description:** Set the value of a Selector of type select to the given option.
@@ -397,6 +410,7 @@ public async selectOption(selector: Selector, option: string | { value?: string,
   - `selector` - The string representing the (select) selector.
   - `option` - The label of the option or an object with properties `value`, `label`, or `index`.
   - `selectorOptions` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<any>` - Returns the array of option values that have been successfully selected.
 
 #### getElement
@@ -415,19 +429,20 @@ public async getElement(selector: Selector, singular?: boolean, selectorOptions?
 #### count
 
 ```typescript
-public async count(selector: Selector, options?: SelectorOptions): Promise<number>;
+public async count(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<number>;
 ```
 
 - **Description:** Counts screen elements which can be found via a selector.
 - **Parameters:**
   - `selector` - The selector.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<number>` - Promise of number of counted elements
 
 #### checkCount
 
 ```typescript
-public async checkCount(selector: Selector, count: number, mode: 'positive' | 'negative',  options?: SelectorOptions): Promise<number>;
+public async checkCount(selector: Selector, count: number, mode: 'positive' | 'negative',  options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<number>;
 ```
 
 - **Description:** Validate if the given element has the given count.
@@ -436,12 +451,13 @@ public async checkCount(selector: Selector, count: number, mode: 'positive' | 'n
   - `count` - The desired count.
   - `mode` - Whether to check if the element has (positive) or has not (negative) the specified count.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<true>` - Promise of true if evaluation met, else exception.
 
 #### checkMinCount
 
 ```typescript
-public async checkMinCount(selector: Selector, count: number, mode: 'positive' | 'negative',  options?: SelectorOptions): Promise<number>;
+public async checkMinCount(selector: Selector, count: number, mode: 'positive' | 'negative',  options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<number>;
 ```
 
 - **Description:** Validate if the given element has the given minimum count.
@@ -450,12 +466,13 @@ public async checkMinCount(selector: Selector, count: number, mode: 'positive' |
   - `count` - The desired minimum count.
   - `mode` - Whether to check if the element has (positive) or has not (negative) the specified minimum count.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<true>` - Promise of true if evaluation met, else exception.
 
 #### checkChecked
 
 ```typescript
-public async checkChecked(selector: Selector, mode: 'positive' | 'negative',  options?: SelectorOptions): Promise<number>;
+public async checkChecked(selector: Selector, mode: 'positive' | 'negative',  options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<number>;
 ```
 
 - **Description:** Validate if the given element is checked.
@@ -463,6 +480,7 @@ public async checkChecked(selector: Selector, mode: 'positive' | 'negative',  op
   - `selector` - The selector.
   - `mode` - Whether to check if the element is (positive) or is not (negative) checked.
   - `options` - (optional) Advanced selector lookup options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<true>` - Promise of true if evaluation met, else exception.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/add.md
+++ b/docs/screenplay_elements/Web/Actions/add.md
@@ -12,6 +12,7 @@ The `Add` class is an action class in the Screenplay pattern designed for use wi
     - [Methods](#methods)
     - [performAs](#performas)
     - [cookies](#cookies)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -38,5 +39,16 @@ public static cookies(cookies: Cookie[]): Add;
 - **Parameters:**
   - `cookies` - The cookies to add.
 - **Returns:** `Add` - Returns a new `Add` instance.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Add;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Add` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/check.md
+++ b/docs/screenplay_elements/Web/Actions/check.md
@@ -45,23 +45,23 @@ public static element(selector: Selector, options?: SelectorOptions): Check;
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Check;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Check` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Check;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Check` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/check.md
+++ b/docs/screenplay_elements/Web/Actions/check.md
@@ -12,6 +12,8 @@ The `Check` class is an action class in the Screenplay pattern designed for use 
     - [Methods](#methods)
     - [performAs](#performas)
     - [element](#element)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -39,5 +41,27 @@ public static element(selector: Selector, options?: SelectorOptions): Check;
   - `selector` - The string representing the selector of the checkbox.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `Check` - Returns a new `Check` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/clear.md
+++ b/docs/screenplay_elements/Web/Actions/clear.md
@@ -12,6 +12,7 @@ The `Clear` class is an action class in the Screenplay pattern designed for use 
     - [Methods](#methods)
     - [performAs](#performas)
     - [cookies](#cookies)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -36,5 +37,16 @@ public static cookies(): Clear;
 
 - **Description:** Creates a new instance of the `Clear` class specifically for clearing browser cookies.
 - **Returns:** `Clear` - Returns a new `Clear` instance.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Clear;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Clear` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/click.md
+++ b/docs/screenplay_elements/Web/Actions/click.md
@@ -12,6 +12,8 @@ The `Click` class is an action class in the Screenplay pattern designed for use 
     - [Methods](#methods)
     - [performAs](#performas)
     - [on](#on)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -39,5 +41,27 @@ public static on(selector: Selector, options?: SelectorOptions): Click;
   - `selector` - The Selector.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `Click` - Returns a new `Click` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/count.md
+++ b/docs/screenplay_elements/Web/Actions/count.md
@@ -12,6 +12,8 @@ The `Count` class is an action class in the Screenplay pattern designed for use 
     - [Methods](#methods)
     - [performAs](#performas)
     - [page](#page)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -39,5 +41,27 @@ public static page(): Count;
   - `selector` - The Selector.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `Count` - Returns a new `Count` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/count.md
+++ b/docs/screenplay_elements/Web/Actions/count.md
@@ -45,23 +45,23 @@ public static page(): Count;
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Count;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Count` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Count;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Count` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/double_click.md
+++ b/docs/screenplay_elements/Web/Actions/double_click.md
@@ -45,23 +45,23 @@ public static on(selector: Selector, options?: SelectorOptions): DoubleClick;
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): DoubleClick;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `DoubleClick` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): DoubleClick;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `DoubleClick` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/double_click.md
+++ b/docs/screenplay_elements/Web/Actions/double_click.md
@@ -12,6 +12,8 @@ The `DoubleClick` class is an action class in the Screenplay pattern designed fo
     - [Methods](#methods)
     - [performAs](#performas)
     - [on](#on)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -39,5 +41,27 @@ public static on(selector: Selector, options?: SelectorOptions): DoubleClick;
   - `selector` - The Selector.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `DoubleClick` - Returns a new `DoubleClick` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/drag_and_drop.md
+++ b/docs/screenplay_elements/Web/Actions/drag_and_drop.md
@@ -49,23 +49,23 @@ public static execute(sourceSelector: Selector, targetSelector: Selector, option
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): DragAndDrop;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `DragAndDrop` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): DragAndDrop;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `DragAndDrop` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/drag_and_drop.md
+++ b/docs/screenplay_elements/Web/Actions/drag_and_drop.md
@@ -12,6 +12,8 @@ The `DragAndDrop` class is an action class in the Screenplay pattern designed fo
     - [Methods](#methods)
     - [performAs](#performas)
     - [execute](#execute)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -43,5 +45,27 @@ public static execute(sourceSelector: Selector, targetSelector: Selector, option
   - `targetSelector` - The selector of the target element.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `DragAndDrop` - Returns a new `DragAndDrop` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/fill.md
+++ b/docs/screenplay_elements/Web/Actions/fill.md
@@ -12,6 +12,8 @@ The `Fill` class is an action class in the Screenplay pattern designed for use w
     - [Methods](#methods)
     - [performAs](#performas)
     - [in](#in)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -40,5 +42,27 @@ public static in(selector: Selector, input: string, options?: SelectorOptions): 
   - `input` - The input string to fill the element with.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `Fill` - Returns a new `Fill` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/fill.md
+++ b/docs/screenplay_elements/Web/Actions/fill.md
@@ -46,23 +46,23 @@ public static in(selector: Selector, input: string, options?: SelectorOptions): 
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Fill;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Fill` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Fill;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Fill` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/get.md
+++ b/docs/screenplay_elements/Web/Actions/get.md
@@ -16,6 +16,7 @@ The `Get` class is an action class in the Screenplay pattern designed for use wi
     - [localStorageItem](#localstorageitem)
     - [element](#element)
     - [elements](#elements)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -88,5 +89,16 @@ public static elements(selector: Selector, options?: SelectorOptions): Get;
   - `selector` - The Selector.
   - `options` (optional) - Advanced selector lookup options.
 - **Returns:** `Get` - Returns a new `Get` instance for a list of screen elements.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Get;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Get` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/hover.md
+++ b/docs/screenplay_elements/Web/Actions/hover.md
@@ -45,23 +45,23 @@ public static over(selector: Selector, options?: SelectorOptions & { modifiers?:
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Hover;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Hover` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Hover;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Hover` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/hover.md
+++ b/docs/screenplay_elements/Web/Actions/hover.md
@@ -12,6 +12,8 @@ The `Hover` class is an action class in the Screenplay pattern designed for use 
     - [Methods](#methods)
     - [performAs](#performas)
     - [over](#over)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -39,5 +41,27 @@ public static over(selector: Selector, options?: SelectorOptions & { modifiers?:
   - `selector` - The selector that should be hovered over.
   - `options` (optional) - Advanced selector lookup options + Modifier keys to press. Ensures that only these modifiers are pressed during the operation.
 - **Returns:** `Hover` - Returns a new `Hover` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/navigate.md
+++ b/docs/screenplay_elements/Web/Actions/navigate.md
@@ -12,6 +12,7 @@ The `Navigate` class is an action class in the Screenplay pattern designed for u
     - [Methods](#methods)
     - [performAs](#performas)
     - [to](#to)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -38,5 +39,16 @@ public static to(url: string): Navigate;
 - **Parameters:**
   - `url` - The URL which should be accessed.
 - **Returns:** `Navigate` - Returns a new `Navigate` instance.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Navigate;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Navigate` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/press.md
+++ b/docs/screenplay_elements/Web/Actions/press.md
@@ -58,23 +58,23 @@ public static pressSequentially(selector: Selector, input: string, options?: Sel
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Press;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Press` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Press;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Press` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/press.md
+++ b/docs/screenplay_elements/Web/Actions/press.md
@@ -12,7 +12,9 @@ The `Press` class is an action class in the Screenplay pattern designed for use 
     - [Methods](#methods)
     - [performAs](#performas)
     - [key](#key)
-    - [pressSequentially](#pressSequentially)
+    - [pressSequentially](#presssequentially)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -52,5 +54,27 @@ public static pressSequentially(selector: Selector, input: string, options?: Sel
   - `input` - The input to type into the element.
   - `options` - (optional) Advanced selector lookup options.
 - **Returns:** `Promise<void>` - Returns when the key(s) have been pressed.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/reload.md
+++ b/docs/screenplay_elements/Web/Actions/reload.md
@@ -12,6 +12,7 @@ The `Reload` class is an action class in the Screenplay pattern designed for use
     - [Methods](#methods)
     - [performAs](#performas)
     - [page](#page)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -36,5 +37,16 @@ public static page(): Reload;
 
 - **Description:** Creates a new instance of the `Reload` class specifically for reloading the currently browsed page.
 - **Returns:** `Reload` - Returns a new `Reload` instance.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Reload;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Reload` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/remove.md
+++ b/docs/screenplay_elements/Web/Actions/remove.md
@@ -13,6 +13,7 @@ The `Remove` class is an action class in the Screenplay pattern designed for use
     - [performAs](#performas)
     - [sessionStorageItem](#sessionstorageitem)
     - [localStorageItem](#localstorageitem)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -50,5 +51,16 @@ public static localStorageItem(key: string): Remove;
 - **Parameters:**
   - `key` - The key that specifies the item to be removed.
 - **Returns:** `Remove` - Returns a new `Remove` instance for local storage.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Remove;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Remove` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/select.md
+++ b/docs/screenplay_elements/Web/Actions/select.md
@@ -12,6 +12,8 @@ The `Select` class is an action class in the Screenplay pattern designed for use
     - [Methods](#methods)
     - [performAs](#performas)
     - [option](#option)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -40,5 +42,27 @@ public static option(selector: Selector, option: string | { value?: string, labe
   - `option` - The label of the option to be selected. It can be either a string or an object with optional properties: `value`, `label`, or `index`.
   - `selectorOptions` - (optional): Advanced selector lookup options.
 - **Returns:** `Select` - Returns a new `Select` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/select.md
+++ b/docs/screenplay_elements/Web/Actions/select.md
@@ -46,23 +46,23 @@ public static option(selector: Selector, option: string | { value?: string, labe
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Select;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Select` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Select;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Select` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/set.md
+++ b/docs/screenplay_elements/Web/Actions/set.md
@@ -13,6 +13,7 @@ The `Set` class is an action class in the Screenplay pattern designed for use wi
     - [performAs](#performas)
     - [sessionStorageItem](#sessionstorageitem)
     - [localStorageItem](#localstorageitem)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -52,5 +53,16 @@ public static localStorageItem(key: string, value: any): Set;
   - `key` - The key that specifies the item.
   - `value` - The value of the item.
 - **Returns:** `Set` - Returns a new `Set` instance for local storage.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Set;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Set` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/type.md
+++ b/docs/screenplay_elements/Web/Actions/type.md
@@ -46,23 +46,23 @@ public static in(selector: Selector, input: string, options?: SelectorOptions): 
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Type;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Type` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Type;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Type` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/type.md
+++ b/docs/screenplay_elements/Web/Actions/type.md
@@ -12,6 +12,8 @@ The `Type` class is an action class in the Screenplay pattern designed for use w
     - [Methods](#methods)
     - [performAs](#performas)
     - [in](#in)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -40,5 +42,27 @@ public static in(selector: Selector, input: string, options?: SelectorOptions): 
   - `input` - The input string to type into the element.
   - `options` - (optional) Advanced selector lookup options.
 - **Returns:** `Type` - Returns a new `Type` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/wait.md
+++ b/docs/screenplay_elements/Web/Actions/wait.md
@@ -13,6 +13,8 @@ The `Wait` class is an action class in the Screenplay pattern designed for use w
     - [performAs](#performas)
     - [forLoadState](#forloadstate)
     - [forSelector](#forselector)
+    - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -52,4 +54,25 @@ public static forSelector(selector: Selector, options?: SelectorOptions): Wait;
   - `options` - (optional) Advanced selector lookup options.
 - **Returns:** `Wait` - Returns a new `Wait` instance.
 
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Click;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Click` - Returns the current action.
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Actions/wait.md
+++ b/docs/screenplay_elements/Web/Actions/wait.md
@@ -57,22 +57,22 @@ public static forSelector(selector: Selector, options?: SelectorOptions): Wait;
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Wait;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Wait` - Returns the current action.
 
 ### withAbilityAlias
 
 ```typescript
-public withAbilityAlias(alias: string): Click;
+public withAbilityAlias(alias: string): Wait;
 ```
 
 - **Description:** Defines the ability alias to be used during execution.
 - **Parameters:**
   - `alias` - The alias.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Wait` - Returns the current action.
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Miscellaneous/utils.md
+++ b/docs/screenplay_elements/Web/Miscellaneous/utils.md
@@ -37,12 +37,12 @@ const getSubLocator = async (locator: Locator, subLocator?: Locator, text?: stri
 ```typescript
 const subLocatorLookup = async ({
     base, locator, timeout, subSelector, state = 'visible',
-}: { base: Page; locator: Locator; timeout?: number; subSelector?: SubSelector, state?: SelectorOptionsState }): Promise<Locator>;
+}: { base: Page | FrameLocator; locator: Locator; timeout?: number; subSelector?: SubSelector, state?: SelectorOptionsState }): Promise<Locator>;
 ```
 
 - **Description:** Performs sub-locator lookup, waiting for selectors to get into the desired state.
 - **Parameters:**
-  - `base` - Playwright page.
+  - `base` | `FrameLocator` - Playwright page or the FrameLocator
   - `locator` - Playwright locator.
   - `timeout` - (optional) Timeout for waiting.
   - `subSelector` - (optional) Sub-selector information.

--- a/docs/screenplay_elements/Web/Miscellaneous/utils.md
+++ b/docs/screenplay_elements/Web/Miscellaneous/utils.md
@@ -13,6 +13,7 @@ This module provides utility functions for working with Playwright locators and 
     - [getSubLocator](#getsublocator)
     - [subLocatorLookup](#sublocatorlookup)
     - [recursiveLocatorLookup](#recursivelocatorlookup)
+    - [recursiveFrameLookup](#recursiveframelookup)
 
 ## Module Overview
 
@@ -35,13 +36,13 @@ const getSubLocator = async (locator: Locator, subLocator?: Locator, text?: stri
 
 ```typescript
 const subLocatorLookup = async ({
-    page, locator, timeout, subSelector, state = 'visible',
-}: { page: Page; locator: Locator; timeout?: number; subSelector?: SubSelector, state?: SelectorOptionsState }): Promise<Locator>;
+    base, locator, timeout, subSelector, state = 'visible',
+}: { base: Page; locator: Locator; timeout?: number; subSelector?: SubSelector, state?: SelectorOptionsState }): Promise<Locator>;
 ```
 
 - **Description:** Performs sub-locator lookup, waiting for selectors to get into the desired state.
 - **Parameters:**
-  - `page` - Playwright page.
+  - `base` - Playwright page.
   - `locator` - Playwright locator.
   - `timeout` - (optional) Timeout for waiting.
   - `subSelector` - (optional) Sub-selector information.
@@ -51,7 +52,7 @@ const subLocatorLookup = async ({
 ### recursiveLocatorLookup
 
 ```typescript
-export const recursiveLocatorLookup = async ({ page, selector, options }: { page: Page; selector: Selector; options?: SelectorOptions }): Promise<Locator>;
+export const recursiveLocatorLookup = async ({ page, selector, options }: { page: Page; selector: Selector; options?: SelectorOptions & { evaluateVisible?: boolean }, frameTree?: FrameSelector[] }): Promise<Locator>;
 ```
 
 - **Description:** Recursively resolves locators, handling sub-selectors and waiting for selectors to become visible.
@@ -59,6 +60,20 @@ export const recursiveLocatorLookup = async ({ page, selector, options }: { page
   - `page` - Playwright page.
   - `selector` - Selector information.
   - `options` - (optional) Selector options.
+  - `frameTree` - An array of frame selector(s).
 - **Returns:** `Promise<Locator>` - Resolves to the final Playwright locator after recursive lookup.
+
+
+### recursiveFrameLookup
+
+```typescript
+export const recursiveFrameLookup = (page: Page, frameTree: FrameSelector[]): FrameLocator;
+```
+
+- **Description:** Resolves frame locators, handling sub-frame locators.
+- **Parameters:**
+  - `page` - Playwright page.
+  - `frameTree` - An array of frame selector(s).
+- **Returns:** `FrameLocator` - Resolves to the final FrameLocator after lookup.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Questions/element.md
+++ b/docs/screenplay_elements/Web/Questions/element.md
@@ -22,6 +22,7 @@ The `Element` class is a question class in the Screenplay pattern designed for u
     - [value](#value)
     - [count](#count)
     - [minCount](#mincount)
+    - [inFrame](#inframe)
 
 ## Class Overview
 
@@ -161,5 +162,16 @@ public minCount(selector: Selector, minimumCount: number, options?: SelectorOpti
   - `minimumCount` - The minimum count.
   - `options` - (optional) Advanced selector lookup options.
 - **Returns:** `Element` - Returns this `Element` instance.
+
+### inFrame
+
+```typescript
+public inFrame(frameSelector: FrameSelector): Click;
+```
+
+- **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
+- **Parameters:**
+  - `frameSelector` - The FrameSelector.
+- **Returns:** `Click` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/docs/screenplay_elements/Web/Questions/element.md
+++ b/docs/screenplay_elements/Web/Questions/element.md
@@ -23,6 +23,7 @@ The `Element` class is a question class in the Screenplay pattern designed for u
     - [count](#count)
     - [minCount](#mincount)
     - [inFrame](#inframe)
+    - [withAbilityAlias](#withabilityalias)
 
 ## Class Overview
 
@@ -166,12 +167,23 @@ public minCount(selector: Selector, minimumCount: number, options?: SelectorOpti
 ### inFrame
 
 ```typescript
-public inFrame(frameSelector: FrameSelector): Click;
+public inFrame(frameSelector: FrameSelector): Element;
 ```
 
 - **Description:** Finds the specified frame selector using the `BrowseTheWeb` ability.
 - **Parameters:**
   - `frameSelector` - The FrameSelector.
-- **Returns:** `Click` - Returns the current action.
+- **Returns:** `Element` - Returns the current action.
+
+### withAbilityAlias
+
+```typescript
+public withAbilityAlias(alias: string): Element;
+```
+
+- **Description:** Defines the ability alias to be used during execution.
+- **Parameters:**
+  - `alias` - The alias.
+- **Returns:** `Element` - Returns the current action.
 
 [Back to overview](../../screenplay_elements.md)

--- a/src/web/abilities/BrowseTheWeb.ts
+++ b/src/web/abilities/BrowseTheWeb.ts
@@ -2,7 +2,7 @@ import {
     Cookie, expect, Locator, Page, Response,
 } from '@playwright/test';
 import { Ability, Actor } from '@testla/screenplay';
-import { Selector, SelectorOptions } from '../types';
+import { FrameSelector, Selector, SelectorOptions } from '../types';
 import { recursiveLocatorLookup } from '../utils';
 import { CheckMode } from '../../types';
 
@@ -209,11 +209,15 @@ export class BrowseTheWeb extends Ability {
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
      * @returns {boolean} Promise<boolean> true if the element is visible/hidden as expected, false if the timeout was reached.
      */
-    public async checkVisibilityState(selector: Selector, mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
+    public async checkVisibilityState(selector: Selector, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
         if (mode === 'positive') {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toBeVisible({ timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).toBeVisible({ timeout: options?.timeout });
         } else {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'hidden' } })).toBeHidden({ timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'hidden' }, frameTree,
+            })).toBeHidden({ timeout: options?.timeout });
         }
         return Promise.resolve(true);
     }

--- a/src/web/abilities/BrowseTheWeb.ts
+++ b/src/web/abilities/BrowseTheWeb.ts
@@ -81,10 +81,13 @@ export class BrowseTheWeb extends Ability {
      *
      * @param {Selector} selector the selector of the element to hover over.
      * @param {SelectorOptions} options (optional) advanced selector lookup options + Modifier keys to press. Ensures that only these modifiers are pressed during the operation.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {void} Returns when hovered over the element
      */
-    public async hover(selector: Selector, options?: SelectorOptions & { modifiers?: ('Alt' | 'Control' | 'Meta' | 'Shift')[] }): Promise<void> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options }))
+    public async hover(selector: Selector, options?: SelectorOptions & { modifiers?: ('Alt' | 'Control' | 'Meta' | 'Shift')[] }, frameTree?: FrameSelector[]): Promise<void> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        }))
             .hover({ modifiers: options?.modifiers });
     }
 
@@ -103,10 +106,13 @@ export class BrowseTheWeb extends Ability {
      *
      * @param {Selector} selector the selector of the checkbox.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {void} Returns after checking the element
      */
-    public async checkBox(selector: Selector, options?: SelectorOptions): Promise<void> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options }))
+    public async checkBox(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        }))
             .check();
     }
 
@@ -115,10 +121,13 @@ export class BrowseTheWeb extends Ability {
      *
      * @param {Selector} selector the selector of the element.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {Locator} Promise<Locator> returns the locator
      */
-    public async waitForSelector(selector: Selector, options?: SelectorOptions): Promise<Locator> {
-        return recursiveLocatorLookup({ page: this.page, selector, options });
+    public async waitForSelector(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<Locator> {
+        return recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        });
     }
 
     /**
@@ -127,14 +136,19 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} sourceSelector the selector of the source element.
      * @param {Selector} targetSelector the selector of the target element.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {void} Returns after dragging the locator to another target locator or target position
      */
     public async dragAndDrop(sourceSelector: Selector, targetSelector: Selector, options?: {
         source?: SelectorOptions;
         target?: SelectorOptions;
-    }): Promise<void> {
-        const target = await recursiveLocatorLookup({ page: this.page, selector: targetSelector, options: options?.target });
-        return (await recursiveLocatorLookup({ page: this.page, selector: sourceSelector, options: options?.source }))
+    }, frameTree?: FrameSelector[]): Promise<void> {
+        const target = await recursiveLocatorLookup({
+            page: this.page, selector: targetSelector, options: options?.target, frameTree,
+        });
+        return (await recursiveLocatorLookup({
+            page: this.page, selector: sourceSelector, options: options?.source, frameTree,
+        }))
             .dragTo(target, { targetPosition: { x: 0, y: 0 } });
     }
 
@@ -144,10 +158,13 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} selector the selector of the source element.
      * @param {string} input the input to fill the element with.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {void} Returns after checks, focuses the element, fills it and triggers an `input` event after filling.
      */
-    public async fill(selector: Selector, input: string, options?: SelectorOptions): Promise<void> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options }))
+    public async fill(selector: Selector, input: string, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        }))
             .fill(input);
     }
 
@@ -157,11 +174,12 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} selector the selector of the source element.
      * @param {string} input the input to type into the element.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s) defining the location for the type event.
      * @return {void} Focuses the element, and then sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
      * @deprecated Please use pressSequentially instead. This function will be removed in the future.
      */
-    public async type(selector: Selector, input: string, options?: SelectorOptions): Promise<void> {
-        return this.pressSequentially(selector, input, options);
+    public async type(selector: Selector, input: string, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void> {
+        return this.pressSequentially(selector, input, options, frameTree);
     }
 
     /**
@@ -170,10 +188,13 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} selector the selector of the source element.
      * @param {string} input the input to type into the element.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s) defining the location for the pressSequentially event.
      * @return {void} Focuses the element, and then sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
      */
-    public async pressSequentially(selector: Selector, input: string, options?: SelectorOptions): Promise<void> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options }))
+    public async pressSequentially(selector: Selector, input: string, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        }))
             .pressSequentially(input);
     }
 
@@ -182,10 +203,13 @@ export class BrowseTheWeb extends Ability {
      *
      * @param {Selector} selector the selector of the element to click.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {void} Returns after clicking the element
      */
-    public async click(selector: Selector, options?: SelectorOptions): Promise<void> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options }))
+    public async click(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        }))
             .click();
     }
 
@@ -194,10 +218,13 @@ export class BrowseTheWeb extends Ability {
      *
      * @param {Selector} selector the selector of the element to double click.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s) defining the location for the double click.
      * @return {void} Returns after double clicking the element
      */
-    public async dblclick(selector: Selector, options?: SelectorOptions): Promise<void> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options }))
+    public async dblclick(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<void> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options, frameTree,
+        }))
             .dblclick();
     }
 
@@ -207,6 +234,7 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} selector the locator to search for.
      * @param {string} mode the expected property of the selector that needs to be checked. either 'visible' or 'hidden'.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @returns {boolean} Promise<boolean> true if the element is visible/hidden as expected, false if the timeout was reached.
      */
     public async checkVisibilityState(selector: Selector, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
@@ -226,15 +254,20 @@ export class BrowseTheWeb extends Ability {
      * Validate if a locator on the page is enabled or disabled.
      *
      * @param {Selector} selector the locator to search for.
-     * @param {string} mode the expected property of the selector that needs to be checked. either 'enabled' or 'disabled'.
+     * @param {string} mode the expected property of the selector that needs to be checked. either 'positive' or 'negative'.
      * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @returns {boolean} true if the element is enabled/disabled as expected, false if the timeout was reached.
      */
-    public async checkEnabledState(selector: Selector, mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
+    public async checkEnabledState(selector: Selector, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
         if (mode === 'positive') {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toBeEnabled({ timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).toBeEnabled({ timeout: options?.timeout });
         } else {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toBeDisabled({ timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).toBeDisabled({ timeout: options?.timeout });
         }
         return Promise.resolve(true);
     }
@@ -242,15 +275,22 @@ export class BrowseTheWeb extends Ability {
     /**
     * Validate if the given element has the given text or not.
     *
-    * @param selector the selector of the element to hover over.
-    * @param text the text to check.
-    * @param options (optional) advanced selector lookup options.
+    * @param {Selector} selector the locator to search for.
+    * @param {string | RegExp} text the expected property of the selector that needs to be checked. either '' or 'disabled'.
+    * @param {string} mode the expected property of the selector that needs to be checked. either 'positive' or 'negative'.
+    * @param {SelectorOptions} options (optional) advanced selector lookup options.
+    * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
+    * @returns {boolean} true if the element is have text/have not text as expected, false if the timeout was reached.
     */
-    public async checkSelectorText(selector: Selector, text: string | RegExp | (string | RegExp)[], mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
+    public async checkSelectorText(selector: Selector, text: string | RegExp | (string | RegExp)[], mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
         if (mode === 'positive') {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toHaveText(text, { timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).toHaveText(text, { timeout: options?.timeout });
         } else {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).not.toHaveText(text, { timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).not.toHaveText(text, { timeout: options?.timeout });
         }
         return Promise.resolve(true);
     }
@@ -258,15 +298,22 @@ export class BrowseTheWeb extends Ability {
     /**
     * Validate if the given element has the given input value or not.
     *
-    * @param selector the selector of the element to hover over.
-    * @param value the single value to check.
-    * @param options (optional) advanced selector lookup options.
+    * @param {Selector} selector the locator to search for.
+    * @param {string | RegExp} value the single value to check.
+    * @param {CheckMode} mode the expected property of the selector that needs to be checked. either 'positive' or 'negative'.
+    * @param {SelectorOptions} options (optional) advanced selector lookup options.
+    * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
+    * @returns {boolean} true if the element is have value/have not value as expected, false if the timeout was reached.
     */
-    public async checkSelectorValue(selector: Selector, value: string | RegExp, mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
+    public async checkSelectorValue(selector: Selector, value: string | RegExp, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
         if (mode === 'positive') {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toHaveValue(value, { timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).toHaveValue(value, { timeout: options?.timeout });
         } else {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).not.toHaveValue(value, { timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).not.toHaveValue(value, { timeout: options?.timeout });
         }
         return Promise.resolve(true);
     }
@@ -274,29 +321,37 @@ export class BrowseTheWeb extends Ability {
     /**
     * Validate if the given element has the given minimum count.
     *
-    * @param selector the selector of the element.
-    * @param count the minumum count of the element to be visible.
-    * @param mode the check mode - whether positive or negative
-    * @param options (optional) advanced selector lookup options.
+    * @param {Selector} selector the selector of the element.
+    * @param {number} count the minumum count of the element to be visible.
+    * @param {CheckMode} mode the check mode - whether positive or negative
+    * @param {SelectorOptions} options (optional) advanced selector lookup options.
+    * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
+    * @returns {boolean} true if the element has the given minimum count as expected, false if the timeout was reached.
     */
-    public async checkMinCount(selector: Selector, count: number, mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
-        await this.checkVisibilityState(`${selector} >> nth=${count - 1}`, mode, options);
+    public async checkMinCount(selector: Selector, count: number, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
+        await this.checkVisibilityState(`${selector} >> nth=${count - 1}`, mode, options, frameTree);
         return Promise.resolve(true);
     }
 
     /**
     * Validate if the given element has the given count.
     *
-    * @param selector the selector of the element.
-    * @param count the exact count of the element to be visible.
-    * @param mode the check mode - whether positive or negative
-    * @param options (optional) advanced selector lookup options.
+    * @param {Selector} selector the selector of the element.
+    * @param {number} count the exact count of the element to be visible.
+    * @param {CheckMode} mode the check mode - whether positive or negative
+    * @param {SelectorOptions} options (optional) advanced selector lookup options.
+    * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
+    * @returns {boolean} true if the element has the given count as expected, false if the timeout was reached.
     */
-    public async checkCount(selector: Selector, count: number, mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
+    public async checkCount(selector: Selector, count: number, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
         if (mode === 'positive') {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible', evaluateVisible: false } })).toHaveCount(count, { timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible', evaluateVisible: false }, frameTree,
+            })).toHaveCount(count, { timeout: options?.timeout });
         } else {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible', evaluateVisible: false } })).not.toHaveCount(count, { timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible', evaluateVisible: false }, frameTree,
+            })).not.toHaveCount(count, { timeout: options?.timeout });
         }
         return Promise.resolve(true);
     }
@@ -304,27 +359,36 @@ export class BrowseTheWeb extends Ability {
     /**
     * Counts screen elements which can be found via a selector.
     *
-    * @param selector the selector of the element.
-    * @param options (optional) advanced selector lookup options.
-    * @returns Promise of number of counted elements
+    * @param {Selector} selector the selector of the element.
+    * @param {SelectorOptions} options (optional) advanced selector lookup options.
+    * @param {FrameSelector[]} [frameTree] - An array of frame selector(s) defining the location for the count.
+    * @returns {boolean} Promise of number of counted elements
     */
-    public async count(selector: Selector, options?: SelectorOptions): Promise<number> {
-        const counted = await (await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible', evaluateVisible: false } })).count();
+    public async count(selector: Selector, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<number> {
+        const counted = await (await recursiveLocatorLookup({
+            page: this.page, selector, options: { ...options, state: 'visible', evaluateVisible: false }, frameTree,
+        })).count();
         return Promise.resolve(counted);
     }
 
     /**
     * Validate if the given element is checked.
     *
-    * @param selector the selector of the element.
-    * @param mode the check mode - whether positive or negative
-    * @param options (optional) advanced selector lookup options.
+    * @param {Selector} selector the selector of the element.
+    * @param {CheckMode} mode the check mode - whether positive or negative
+    * @param {SelectorOptions} options (optional) advanced selector lookup options.
+    * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
+    * @returns {boolean} true if the element is checked or not checked
     */
-    public async checkChecked(selector: Selector, mode: CheckMode, options?: SelectorOptions): Promise<boolean> {
+    public async checkChecked(selector: Selector, mode: CheckMode, options?: SelectorOptions, frameTree?: FrameSelector[]): Promise<boolean> {
         if (mode === 'positive') {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toBeChecked({ timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).toBeChecked({ timeout: options?.timeout });
         } else {
-            await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).not.toBeChecked({ timeout: options?.timeout });
+            await expect(await recursiveLocatorLookup({
+                page: this.page, selector, options: { ...options, state: 'visible' }, frameTree,
+            })).not.toBeChecked({ timeout: options?.timeout });
         }
         return Promise.resolve(true);
     }
@@ -447,10 +511,13 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} selector the string representing the (select) selector.
      * @param {string} option the label of the option.
      * @param {SelectorOptions} selectorOptions (optional): advanced selector lookup options.
+     * @param {FrameSelector[]} [frameTree] - An array of frame selector(s).
      * @return {any} Returns the array of option values that have been successfully selected.
      */
-    public async selectOption(selector: Selector, option: string | { value?: string, label?: string, index?: number }, selectorOptions?: SelectorOptions): Promise<any> {
-        return (await recursiveLocatorLookup({ page: this.page, selector, options: selectorOptions })).selectOption(option);
+    public async selectOption(selector: Selector, option: string | { value?: string, label?: string, index?: number }, selectorOptions?: SelectorOptions, frameTree?: FrameSelector[]): Promise<any> {
+        return (await recursiveLocatorLookup({
+            page: this.page, selector, options: selectorOptions, frameTree,
+        })).selectOption(option);
     }
 
     /**
@@ -459,7 +526,7 @@ export class BrowseTheWeb extends Ability {
      * @param {Selector} selector the string or locator representing the selector.
      * @param {boolean} singular (optional): the indicator whether to return a single item or a list of items. In case of single item the first item is returned if more than 1 items are found. Defaults to true.
      * @param {SelectorOptions} options (optional): advanced selector lookup options.
-     * @returns A single screen element or a list of screen elements depending on the singular input parameter.
+     * @returns {Locator | Locator[]} A single screen element or a list of screen elements depending on the singular input parameter.
      */
     public async getElement(selector: Selector, singular = true, selectorOptions: SelectorOptions = {}): Promise<Locator | Locator[]> {
         let locators;

--- a/src/web/actions/Check.ts
+++ b/src/web/actions/Check.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Check a checkbox specified by a selector string.
  */
-export class Check extends Action {
+export class Check extends FrameEnabledAction {
     private constructor(private selector: Selector, private options?: SelectorOptions) {
         super();
     }
@@ -17,7 +18,7 @@ export class Check extends Action {
      * @return {void} Returns after checking the element
      */
     public async performAs(actor: Actor): Promise<void> {
-        await BrowseTheWeb.as(actor, this.abilityAlias).checkBox(this.selector, this.options);
+        await BrowseTheWeb.as(actor, this.abilityAlias).checkBox(this.selector, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Click.ts
+++ b/src/web/actions/Click.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Click on an element specified by a selector string.
  */
-export class Click extends Action {
+export class Click extends FrameEnabledAction {
     private constructor(private selector: Selector, private options?: SelectorOptions) {
         super();
     }
@@ -17,7 +18,7 @@ export class Click extends Action {
      * @return {void} Returns after clicking the element
      */
     public async performAs(actor: Actor): Promise<void> {
-        await BrowseTheWeb.as(actor, this.abilityAlias).click(this.selector, this.options);
+        await BrowseTheWeb.as(actor, this.abilityAlias).click(this.selector, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Count.ts
+++ b/src/web/actions/Count.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { Selector, SelectorOptions } from '../types';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Count elements.
  */
-export class Count extends Action {
+export class Count extends FrameEnabledAction {
     private selector: Selector;
 
     private options?: SelectorOptions;
@@ -25,7 +26,7 @@ export class Count extends Action {
      */
     // eslint-disable-next-line class-methods-use-this
     public performAs(actor: Actor): Promise<number> {
-        return BrowseTheWeb.as(actor, this.abilityAlias).count(this.selector, this.options);
+        return BrowseTheWeb.as(actor, this.abilityAlias).count(this.selector, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/DoubleClick.ts
+++ b/src/web/actions/DoubleClick.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Click on an element specified by a selector string.
  */
-export class DoubleClick extends Action {
+export class DoubleClick extends FrameEnabledAction {
     // eslint-disable-next-line no-useless-constructor
     private constructor(private selector: Selector, private options?: SelectorOptions) {
         super();
@@ -18,7 +19,7 @@ export class DoubleClick extends Action {
      * @return {void} Returns after double clicking the element
      */
     public async performAs(actor: Actor): Promise<void> {
-        await BrowseTheWeb.as(actor, this.abilityAlias).dblclick(this.selector, this.options);
+        await BrowseTheWeb.as(actor, this.abilityAlias).dblclick(this.selector, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/DragAndDrop.ts
+++ b/src/web/actions/DragAndDrop.ts
@@ -1,12 +1,13 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. DragAndDrop an element specified by a selector string and drop it on an element specified by another
  * selector string.
  */
-export class DragAndDrop extends Action {
+export class DragAndDrop extends FrameEnabledAction {
     private constructor(private sourceSelector: Selector, private targetSelector: Selector, private options?: {
         source?: SelectorOptions;
         target?: SelectorOptions;
@@ -20,7 +21,7 @@ export class DragAndDrop extends Action {
      * @return {void} Returns after dragging the locator to another target locator or target position
      */
     public performAs(actor: Actor): Promise<void> {
-        return BrowseTheWeb.as(actor, this.abilityAlias).dragAndDrop(this.sourceSelector, this.targetSelector, this.options);
+        return BrowseTheWeb.as(actor, this.abilityAlias).dragAndDrop(this.sourceSelector, this.targetSelector, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Fill.ts
+++ b/src/web/actions/Fill.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Fill an element specified by a selector string with the specified input.
  */
-export class Fill extends Action {
+export class Fill extends FrameEnabledAction {
     private constructor(private selector: Selector, private input: string, private options?: SelectorOptions) {
         super();
     }
@@ -17,7 +18,7 @@ export class Fill extends Action {
      * @return {void} Returns after checks, focuses the element, fills it and triggers an `input` event after filling.
      */
     public async performAs(actor: Actor): Promise<void> {
-        return BrowseTheWeb.as(actor, this.abilityAlias).fill(this.selector, this.input, this.options);
+        return BrowseTheWeb.as(actor, this.abilityAlias).fill(this.selector, this.input, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Hover.ts
+++ b/src/web/actions/Hover.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Hover over an element specified by a selector string.
  */
-export class Hover extends Action {
+export class Hover extends FrameEnabledAction {
     private constructor(private selector: Selector, private options?: SelectorOptions & { modifiers?: ('Alt' | 'Control' | 'Meta' | 'Shift')[] }) {
         super();
     }
@@ -17,7 +18,7 @@ export class Hover extends Action {
      * @return {void} Returns when hovered over the element
      */
     public performAs(actor: Actor): Promise<void> {
-        return BrowseTheWeb.as(actor, this.abilityAlias).hover(this.selector, this.options);
+        return BrowseTheWeb.as(actor, this.abilityAlias).hover(this.selector, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Press.ts
+++ b/src/web/actions/Press.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { Selector, SelectorOptions } from '../types';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Press the specified key on the keyboard.
  */
-export class Press extends Action {
+export class Press extends FrameEnabledAction {
     private constructor(private mode: 'key' | 'sequentially', private payload: any) {
         super();
     }
@@ -20,7 +21,7 @@ export class Press extends Action {
         if (this.mode === 'key') {
             return BrowseTheWeb.as(actor, this.abilityAlias).press(this.payload.keys);
         }
-        return BrowseTheWeb.as(actor, this.abilityAlias).pressSequentially(this.payload.selector, this.payload.input, this.payload.options);
+        return BrowseTheWeb.as(actor, this.abilityAlias).pressSequentially(this.payload.selector, this.payload.input, this.payload.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Select.ts
+++ b/src/web/actions/Select.ts
@@ -1,10 +1,11 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { Selector, SelectorOptions } from '../types';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 /**
  * Action Class. Set the value of a Selector of type select to the given option.
  */
-export class Select extends Action {
+export class Select extends FrameEnabledAction {
     private constructor(private selector: Selector, private option: string | { value?: string, label?: string, index?: number }, private selectorOptions?: SelectorOptions) {
         super();
     }
@@ -16,7 +17,7 @@ export class Select extends Action {
      * @return {any} This method checks, waits until all specified options are present in the `<select>` element and selects these options.
      */
     public async performAs(actor: Actor): Promise<any> {
-        await BrowseTheWeb.as(actor, this.abilityAlias).selectOption(this.selector, this.option, this.selectorOptions);
+        await BrowseTheWeb.as(actor, this.abilityAlias).selectOption(this.selector, this.option, this.selectorOptions, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Type.ts
+++ b/src/web/actions/Type.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Type specified input into an element specified by a selector string.
  */
-export class Type extends Action {
+export class Type extends FrameEnabledAction {
     private constructor(private selector: Selector, private input: string, private options?: SelectorOptions) {
         super();
     }
@@ -17,7 +18,7 @@ export class Type extends Action {
      * @return {void} Focuses the element, and then sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
      */
     public async performAs(actor: Actor): Promise<void> {
-        return BrowseTheWeb.as(actor, this.abilityAlias).type(this.selector, this.input, this.options);
+        return BrowseTheWeb.as(actor, this.abilityAlias).type(this.selector, this.input, this.options, this.frameTree);
     }
 
     /**

--- a/src/web/actions/Wait.ts
+++ b/src/web/actions/Wait.ts
@@ -1,11 +1,12 @@
-import { Action, Actor } from '@testla/screenplay';
+import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
+import { FrameEnabledAction } from '../templates/FrameEnabledAction';
 
 /**
  * Action Class. Wait for either a specified loading state or for a selector to become visible/active.
  */
-export class Wait extends Action {
+export class Wait extends FrameEnabledAction {
     // the object that determines what to wait for (loading state, selector or selector == expected).
     // only 1 property is active at all times.
     private action: {
@@ -29,7 +30,7 @@ export class Wait extends Action {
             return BrowseTheWeb.as(actor, this.abilityAlias).waitForLoadState(this.action.payload.state);
         }
         if (this.action.mode === 'selector') {
-            return BrowseTheWeb.as(actor, this.abilityAlias).waitForSelector(this.action.payload.selector, this.action.payload.options);
+            return BrowseTheWeb.as(actor, this.abilityAlias).waitForSelector(this.action.payload.selector, this.action.payload.options, this.frameTree);
         }
         throw new Error('Error: no match for Wait.performAs()!');
     }

--- a/src/web/questions/Element.ts
+++ b/src/web/questions/Element.ts
@@ -1,20 +1,19 @@
-import { Actor, Question } from '@testla/screenplay';
-import { FrameSelector, Selector, SelectorOptions } from '../types';
+import { Actor } from '@testla/screenplay';
+import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { CheckMode } from '../../types';
+import { BaseQuestion } from '../templates/BaseQuestion';
 
 type Mode = 'visible' | 'enabled' | 'text' | 'value' | 'count' | 'minCount' | 'checked';
 
 /**
  * Question Class. Get a specified state for a selector like visible or enabled.
  */
-export class Element extends Question<boolean> {
+export class Element extends BaseQuestion {
     private mode: Mode = 'visible';
 
     // the selector of the element to check.
     private selector: Selector = '';
-
-    private frameTree: FrameSelector[] = [];
 
     // text or value to check.
     private payload: number | string | RegExp | (string | RegExp)[] = '';
@@ -40,19 +39,19 @@ export class Element extends Question<boolean> {
         }
         if (this.mode === 'enabled') {
             return Promise.resolve(
-                await BrowseTheWeb.as(actor).checkEnabledState(this.selector, this.checkMode, this.options),
+                await BrowseTheWeb.as(actor).checkEnabledState(this.selector, this.checkMode, this.options, this.frameTree),
             ); // if the ability method is not the expected result there will be an exception
         }
         if (this.mode === 'text') {
             return Promise.resolve(
-                await BrowseTheWeb.as(actor).checkSelectorText(this.selector, this.payload as string, this.checkMode, this.options),
+                await BrowseTheWeb.as(actor).checkSelectorText(this.selector, this.payload as string, this.checkMode, this.options, this.frameTree),
             ); // if the ability method is not the expected result there will be an exception
         }
         if (this.mode === 'value') {
             // Element.values was called -> need to check multiple values
             if (!Array.isArray(this.payload)) {
                 return Promise.resolve(
-                    await BrowseTheWeb.as(actor).checkSelectorValue(this.selector, this.payload as string, this.checkMode, this.options),
+                    await BrowseTheWeb.as(actor).checkSelectorValue(this.selector, this.payload as string, this.checkMode, this.options, this.frameTree),
                 ); // if the ability method is not the expected result there will be an exception
             }
 
@@ -60,17 +59,17 @@ export class Element extends Question<boolean> {
         }
         if (this.mode === 'checked') {
             return Promise.resolve(
-                await BrowseTheWeb.as(actor).checkChecked(this.selector, this.checkMode, this.options),
+                await BrowseTheWeb.as(actor).checkChecked(this.selector, this.checkMode, this.options, this.frameTree),
             ); // if the ability method is not the expected result there will be an exception
         }
         if (this.mode === 'count') {
             return Promise.resolve(
-                await BrowseTheWeb.as(actor).checkCount(this.selector, this.payload as number, this.checkMode, { ...this.options }),
+                await BrowseTheWeb.as(actor).checkCount(this.selector, this.payload as number, this.checkMode, { ...this.options }, this.frameTree),
             ); // if the ability method is not the expected result there will be an exception
         }
         if (this.mode === 'minCount') {
             return Promise.resolve(
-                await BrowseTheWeb.as(actor).checkMinCount(this.selector, this.payload as number, this.checkMode, this.options),
+                await BrowseTheWeb.as(actor).checkMinCount(this.selector, this.payload as number, this.checkMode, this.options, this.frameTree),
             ); // if the ability method is not the expected result there will be an exception
         }
         throw new Error('Unknown mode: Element.answeredBy');
@@ -120,11 +119,6 @@ export class Element extends Question<boolean> {
         this.selector = selector;
         this.options = options;
 
-        return this;
-    }
-
-    public inFrame(frameSelector: FrameSelector): Element {
-        this.frameTree.push(frameSelector);
         return this;
     }
 

--- a/src/web/questions/Element.ts
+++ b/src/web/questions/Element.ts
@@ -2,14 +2,14 @@ import { Actor } from '@testla/screenplay';
 import { Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { CheckMode } from '../../types';
-import { BaseQuestion } from '../templates/BaseQuestion';
+import { FrameEnabledQuestion } from '../templates/FrameEnabledQuestion';
 
 type Mode = 'visible' | 'enabled' | 'text' | 'value' | 'count' | 'minCount' | 'checked';
 
 /**
  * Question Class. Get a specified state for a selector like visible or enabled.
  */
-export class Element extends BaseQuestion {
+export class Element extends FrameEnabledQuestion {
     private mode: Mode = 'visible';
 
     // the selector of the element to check.

--- a/src/web/questions/Element.ts
+++ b/src/web/questions/Element.ts
@@ -1,5 +1,5 @@
 import { Actor, Question } from '@testla/screenplay';
-import { Selector, SelectorOptions } from '../types';
+import { FrameSelector, Selector, SelectorOptions } from '../types';
 import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { CheckMode } from '../../types';
 
@@ -13,6 +13,8 @@ export class Element extends Question<boolean> {
 
     // the selector of the element to check.
     private selector: Selector = '';
+
+    private frameTree: FrameSelector[] = [];
 
     // text or value to check.
     private payload: number | string | RegExp | (string | RegExp)[] = '';
@@ -33,7 +35,7 @@ export class Element extends Question<boolean> {
     public async answeredBy(actor: Actor): Promise<boolean> {
         if (this.mode === 'visible') {
             return Promise.resolve(
-                await BrowseTheWeb.as(actor).checkVisibilityState(this.selector, this.checkMode, this.options),
+                await BrowseTheWeb.as(actor).checkVisibilityState(this.selector, this.checkMode, this.options, this.frameTree),
             ); // if the ability method is not the expected result there will be an exception
         }
         if (this.mode === 'enabled') {
@@ -118,6 +120,11 @@ export class Element extends Question<boolean> {
         this.selector = selector;
         this.options = options;
 
+        return this;
+    }
+
+    public inFrame(frameSelector: FrameSelector): Element {
+        this.frameTree.push(frameSelector);
         return this;
     }
 

--- a/src/web/templates/BaseQuestion.ts
+++ b/src/web/templates/BaseQuestion.ts
@@ -1,0 +1,18 @@
+import { Question } from '@testla/screenplay';
+import { FrameSelector } from '../types';
+
+export abstract class BaseQuestion extends Question<boolean> {
+    // value which will be forwared to call the actual frame(s)
+    public frameTree: FrameSelector[] = [];
+
+    /**
+     * Set the frameSelector which is used for the action.
+     *
+     * @param {FrameSelector} frameSelector frame selector.
+     * @returns current action
+     */
+    public inFrame(frameSelector: FrameSelector) {
+        this.frameTree.push(frameSelector);
+        return this;
+    }
+}

--- a/src/web/templates/FrameEnabledAction.ts
+++ b/src/web/templates/FrameEnabledAction.ts
@@ -1,0 +1,18 @@
+import { Action } from '@testla/screenplay';
+import { FrameSelector } from '../types';
+
+export abstract class FrameEnabledAction extends Action {
+    // value which will be forwared to call the actual frame(s)
+    public frameTree: FrameSelector[] = [];
+
+    /**
+     * Set the frameSelector which is used for the action.
+     *
+     * @param {FrameSelector} frameSelector frame selector.
+     * @returns current action
+     */
+    public inFrame(frameSelector: FrameSelector) {
+        this.frameTree.push(frameSelector);
+        return this;
+    }
+}

--- a/src/web/templates/FrameEnabledQuestion.ts
+++ b/src/web/templates/FrameEnabledQuestion.ts
@@ -1,7 +1,7 @@
 import { Question } from '@testla/screenplay';
 import { FrameSelector } from '../types';
 
-export abstract class BaseQuestion extends Question<boolean> {
+export abstract class FrameEnabledQuestion extends Question<boolean> {
     // value which will be forwared to call the actual frame(s)
     public frameTree: FrameSelector[] = [];
 

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -2,6 +2,8 @@ import { Locator } from '@playwright/test';
 
 export type Selector = string | Locator;
 
+export type FrameSelector = string;
+
 export type SelectorOptionsState = 'visible' | 'hidden' | 'attached' | 'detached';
 
 export type SubSelector = [

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable vars-on-top */
-import { Locator, Page } from '@playwright/test';
+import { FrameLocator, Locator, Page } from '@playwright/test';
 import {
+    FrameSelector,
     Selector, SelectorOptions, SelectorOptionsState, SubSelector,
 } from './types';
 
@@ -8,8 +9,8 @@ import {
 const getSubLocator = async (locator: Locator, subLocator?: Locator, text?: string | RegExp): Promise<Locator> => locator.filter({ has: subLocator, hasText: text });
 
 const subLocatorLookup = async ({
-    page, locator, timeout, subSelector, state = 'visible', evaluateVisible = true,
-}: { page: Page; locator: Locator; timeout?: number; subSelector?: SubSelector; state?: SelectorOptionsState; evaluateVisible?: boolean }): Promise<Locator> => {
+    base, locator, timeout, subSelector, state = 'visible', evaluateVisible = true,
+}: { base: Page | FrameLocator; locator: Locator; timeout?: number; subSelector?: SubSelector; state?: SelectorOptionsState; evaluateVisible?: boolean }): Promise<Locator> => {
     let resolvedLocator: Locator = locator;
     // wait for selector to become visible based on timeout options
     if (evaluateVisible) {
@@ -27,18 +28,29 @@ const subLocatorLookup = async ({
 
         if (subSelector[1]?.subSelector) {
             resolvedLocator = await subLocatorLookup({
-                page, locator: resolvedLocator, timeout: subSelector[1]?.timeout, subSelector: subSelector[1]?.subSelector, state: subSelector[1]?.state,
+                base, locator: resolvedLocator, timeout: subSelector[1]?.timeout, subSelector: subSelector[1]?.subSelector, state: subSelector[1]?.state,
             });
         }
     }
     return Promise.resolve(resolvedLocator);
 };
 
-export const recursiveLocatorLookup = async ({ page, selector, options }: { page: Page; selector: Selector; options?: SelectorOptions & { evaluateVisible?: boolean } }): Promise<Locator> => {
+export const recursiveFrameLookup = (page: Page, frameTree: FrameSelector[]): FrameLocator => {
+    let base = page as unknown as FrameLocator;
+    frameTree.forEach((node) => {
+        base = base.frameLocator(node);
+    });
+    return base;
+};
+
+export const recursiveLocatorLookup = async ({
+    page, selector, options, frameTree,
+}: { page: Page; selector: Selector; options?: SelectorOptions & { evaluateVisible?: boolean }, frameTree?: FrameSelector[] }): Promise<Locator> => {
+    const base = frameTree === undefined || frameTree.length === 0 ? page : recursiveFrameLookup(page, frameTree);
     // find first level locator: if selector is a string, need to find it using page.locator(), if it is already a Playwright Locator use it directly.
-    const locator = typeof selector === 'string' ? page.locator(selector, { hasText: options?.hasText }) : await getSubLocator(selector, undefined, options?.hasText);
+    const locator = typeof selector === 'string' ? base.locator(selector, { hasText: options?.hasText }) : await getSubLocator(selector, undefined, options?.hasText);
     // pass the first level locator into sub locator lookup
     return subLocatorLookup({
-        page, locator, timeout: options?.timeout, subSelector: options?.subSelector, state: options?.state, evaluateVisible: options?.evaluateVisible,
+        base, locator, timeout: options?.timeout, subSelector: options?.subSelector, state: options?.state, evaluateVisible: options?.evaluateVisible,
     });
 };


### PR DESCRIPTION
Issue number: resolves #53 

## Proposed changes

A page can have one or more frame objects attached to it. Each page has a main frame and page-level interactions (like click) are assumed to operate in the main frame.

A page can have additional frames attached with the iframe HTML tag. These frames can be accessed for interactions inside the frame.

FrameLocator represents a view to the iframe on the page. It captures the logic sufficient to retrieve the iframe and locate elements in that iframe.

## Types of changes

What types of changes does your code introduce to Testla?
_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Regression
- [x] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and (unit) tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation
- [x] I have considered ability aliasing
