### PR TITLE
Allow lazy loading of locators in web actions 

### DIFF
--- a/__tests__/web_playwright_locators.spec.ts
+++ b/__tests__/web_playwright_locators.spec.ts
@@ -357,4 +357,22 @@ test.describe('Testing screenplay-playwright-js web module', () => {
         }
         expect(notEnabledRes).toBeTruthy();
     });
+
+    test('Click with lazy selector', async ({ actor }) => {
+        const page: Page = BrowseTheWeb.as(actor).getPage();
+
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/add_remove_elements/'),
+            Wait.forLoadState('networkidle'),
+        );
+        // assert that there is no button before we add it with our Click
+        await expect(page.locator('[class="added-manually"]')).toHaveCount(0);
+
+        await actor.attemptsTo(
+            Click.on((runtimePage) => runtimePage.getByRole('button', { name: 'Add Element' })),
+        );
+
+        // assert that the button is here after our Click
+        await expect(page.locator('[class="added-manually"]')).toHaveCount(1);
+    });
 });

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,6 +1,8 @@
-import { Locator } from '@playwright/test';
+import { FrameLocator, Locator, Page } from '@playwright/test';
 
-export type Selector = string | Locator;
+export type LazySelector = (page: Page | FrameLocator) => Locator;
+
+export type Selector = string | Locator | LazySelector;
 
 export type FrameSelector = string;
 


### PR DESCRIPTION
Issue number: resolves #66 

## Proposed changes

Allow lazy loading of locators in web actions

Extend the handling of web Actions so that the Locator can be provided
via a function. This allows for the lazy loading of Loacator objects
based on the Playwright Page provided at execution time. This allows for
the use of advanced features in Playwright for selecting elements, such
as the getByRole() function, which could not as easily used previously.

## Types of changes

What types of changes does your code introduce to Testla?
_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] New feature
- [ ] Regression
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and (unit) tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated necessary documentation
- [ ] I have considered ability aliasing

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
