### PR TITLE
Add aliasing in Element questions

### DIFF
--- a/__tests__/aliasing.spec.ts
+++ b/__tests__/aliasing.spec.ts
@@ -3,6 +3,7 @@ import { Actor } from '@testla/screenplay';
 import { UseAPI } from '../src/api/abilities/UseAPI';
 import { Get } from '../src/api/actions/Get';
 import { BrowseTheWeb, Navigate } from '../src/web';
+import { Element } from '../src/web/questions/Element';
 
 const ALIAS = 'alias';
 
@@ -47,5 +48,15 @@ test.describe('Testing screenplay-playwright-js ability aliasing', () => {
             Navigate.to('https://google.com').withAbilityAlias(ALIAS),
         );
         await expect(BrowseTheWeb.as(actor, ALIAS).getPage()).toHaveURL('https://www.google.com');
+    });
+
+    test('BrowseTheWeb - Question with aliasing', async ({ actor }) => {
+        await actor.attemptsTo(
+            Navigate.to('https://the-internet.herokuapp.com/tables').withAbilityAlias(ALIAS),
+        );
+
+        await actor.asks(
+            Element.toHave.text('h3', 'Data Tables').withAbilityAlias(ALIAS),
+        );
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testla/screenplay-playwright",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Implementation of the Playwright abilities, actions and questions.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,7 @@
 version: "1.0"
-linter: jetbrains/qodana-js:2023.3
+linter: jetbrains/qodana-js:2024.1
 include:
   - name: CheckDependencyLicenses
   - name: DuplicatedCode
+exclude:
+  - name: ES6PreferShortImport

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -3,19 +3,43 @@ import { Add } from './actions/Add';
 import { Check } from './actions/Check';
 import { Clear } from './actions/Clear';
 import { Click } from './actions/Click';
+import { Count } from './actions/Count';
 import { DoubleClick } from './actions/DoubleClick';
+import { Download } from './actions/Download';
 import { DragAndDrop } from './actions/DragAndDrop';
 import { Fill } from './actions/Fill';
 import { Get } from './actions/Get';
 import { Hover } from './actions/Hover';
 import { Navigate } from './actions/Navigate';
 import { Press } from './actions/Press';
+import { Reload } from './actions/Reload';
 import { Remove } from './actions/Remove';
+import { Select } from './actions/Select';
 import { Set } from './actions/Set';
 import { Type } from './actions/Type';
 import { Wait } from './actions/Wait';
 import { Element } from './questions/Element';
 
 export {
-    BrowseTheWeb, Check, Wait, Hover, Navigate, Fill, Press, DragAndDrop, Click, DoubleClick, Type, Element, Get, Add, Clear, Remove, Set,
+    BrowseTheWeb,
+    Add,
+    Check,
+    Clear,
+    Click,
+    Count,
+    DoubleClick,
+    Download,
+    DragAndDrop,
+    Fill,
+    Get,
+    Hover,
+    Navigate,
+    Press,
+    Reload,
+    Remove,
+    Select,
+    Set,
+    Type,
+    Wait,
+    Element,
 };

--- a/src/web/questions/Element.ts
+++ b/src/web/questions/Element.ts
@@ -34,11 +34,11 @@ export class Element extends FrameEnabledQuestion {
      */
     public async answeredBy(actor: Actor): Promise<boolean> {
         const {
-            mode, selector, payload, checkMode, options, frameTree,
+            mode, selector, payload, checkMode, options, frameTree, abilityAlias,
         } = this;
 
         if (mode === 'visible') {
-            const locator = await BrowseTheWeb.as(actor).resolveSelectorToLocator(selector, { ...options, state: checkMode === 'positive' ? 'visible' : 'hidden' }, frameTree);
+            const locator = await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(selector, { ...options, state: checkMode === 'positive' ? 'visible' : 'hidden' }, frameTree);
 
             if (this.checkMode === 'positive') {
                 await expect(locator).toBeVisible({ timeout: options?.timeout });
@@ -49,7 +49,7 @@ export class Element extends FrameEnabledQuestion {
             return Promise.resolve(true); // if the ability method is not the expected result there will be an exception
         }
         if (mode === 'enabled') {
-            const locator = await BrowseTheWeb.as(actor).resolveSelectorToLocator(selector, options, frameTree);
+            const locator = await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(selector, options, frameTree);
 
             if (this.checkMode === 'positive') {
                 await expect(locator).toBeEnabled({ timeout: options?.timeout });
@@ -59,7 +59,7 @@ export class Element extends FrameEnabledQuestion {
             return Promise.resolve(true); // if the ability method is not the expected result there will be an exception
         }
         if (mode === 'text') {
-            const locator = await BrowseTheWeb.as(actor).resolveSelectorToLocator(selector, options, frameTree);
+            const locator = await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(selector, options, frameTree);
 
             if (this.checkMode === 'positive') {
                 await expect(locator).toHaveText(payload as string, { timeout: options?.timeout });
@@ -69,7 +69,7 @@ export class Element extends FrameEnabledQuestion {
             return Promise.resolve(true); // if the ability method is not the expected result there will be an exception
         }
         if (mode === 'value') {
-            const locator = await BrowseTheWeb.as(actor).resolveSelectorToLocator(selector, options, frameTree);
+            const locator = await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(selector, options, frameTree);
 
             if (this.checkMode === 'positive') {
                 await expect(locator).toHaveValue(payload as string | RegExp, { timeout: options?.timeout });
@@ -79,7 +79,7 @@ export class Element extends FrameEnabledQuestion {
             return Promise.resolve(true); // if the ability method is not the expected result there will be an exception
         }
         if (mode === 'checked') {
-            const locator = await BrowseTheWeb.as(actor).resolveSelectorToLocator(selector, options, frameTree);
+            const locator = await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(selector, options, frameTree);
 
             if (this.checkMode === 'positive') {
                 await expect(locator).toBeChecked({ timeout: options?.timeout });
@@ -89,7 +89,7 @@ export class Element extends FrameEnabledQuestion {
             return Promise.resolve(true); // if the ability method is not the expected result there will be an exception
         }
         if (mode === 'count') {
-            const locator = await BrowseTheWeb.as(actor).resolveSelectorToLocator(selector, { ...options, evaluateVisible: false }, frameTree);
+            const locator = await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(selector, { ...options, evaluateVisible: false }, frameTree);
 
             if (this.checkMode === 'positive') {
                 await expect(locator).toHaveCount(payload as number, { timeout: options?.timeout });
@@ -100,9 +100,9 @@ export class Element extends FrameEnabledQuestion {
         }
         if (mode === 'minCount') {
             if (checkMode === 'positive') {
-                await BrowseTheWeb.as(actor).resolveSelectorToLocator(`${selector} >> nth=${payload as number - 1}`, options, frameTree);
+                await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(`${selector} >> nth=${payload as number - 1}`, options, frameTree);
             } else {
-                await BrowseTheWeb.as(actor).resolveSelectorToLocator(`${selector} >> nth=${payload as number - 1}`, { ...options, state: 'hidden' }, frameTree);
+                await BrowseTheWeb.as(actor, abilityAlias).resolveSelectorToLocator(`${selector} >> nth=${payload as number - 1}`, { ...options, state: 'hidden' }, frameTree);
             }
 
             return Promise.resolve(true);


### PR DESCRIPTION
Issue number: resolves #86 & #87 

## Proposed changes

I checked all exported member and add they which were missed. 
Updated the Element class to enable validating an element with ability aliasing.

## Types of changes

What types of changes does your code introduce to Testla?
_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature
- [ ] Regression
- [ ] Documentation Update

## Checklist

- [x] Lint and (unit) tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated necessary documentation
- [x] I have considered ability aliasing
- [ ] I have considered logging
